### PR TITLE
Check for the X-Forward protocol is missing

### DIFF
--- a/concrete/bootstrap/start.php
+++ b/concrete/bootstrap/start.php
@@ -20,6 +20,15 @@ if (basename($_SERVER['PHP_SELF']) == DISPATCHER_FILENAME_CORE) {
 
 /*
  * ----------------------------------------------------------------------------
+ * Check for loadbalanced solutions and add the https flag.
+ * ----------------------------------------------------------------------------
+ */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
+
+/*
+ * ----------------------------------------------------------------------------
  * Instantiate concrete5.
  * ----------------------------------------------------------------------------
  */


### PR DESCRIPTION
On loadbalanceed solutions the X-Forward protocol is not checked, meaning the SSL flag is not set.